### PR TITLE
Fixing production build for agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ curl -X POST http://localhost:3000/v1/data-gov/search \
 
 ## Project Structure
 
-> **Note on Import Paths**: This project uses relative imports (e.g., `../../lib/utils.ts`) rather than aliased imports (e.g., `@/lib/utils`). While aliased imports would improve readability, they are not easily configurable for serverless deployment environments without additional build complexity. I apologize for any inconvenience this may cause when navigating the codebase.
+> **Note on Import Paths**: This project uses relative imports (e.g., `../../lib/utils.ts`) rather than aliased imports (e.g., `@/lib/utils`). I did everything with aliased imports and it was beautiful, but then I had to remove them to make the app servable on Vercel. There were other solutions, they would just involve deeper rewrites.
 
 ```
 ├── src/

--- a/bun.lock
+++ b/bun.lock
@@ -27,7 +27,6 @@
         "jest-image-snapshot": "^6.5.1",
         "prettier": "^3.2.5",
         "sharp": "^0.34.4",
-        "tsc-alias": "^1.8.16",
         "typescript": "^5.3.3",
         "vitest": "^3.2.4",
       },
@@ -338,8 +337,6 @@
 
     "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
-    "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
-
     "archiver": ["archiver@5.3.2", "", { "dependencies": { "archiver-utils": "^2.1.0", "async": "^3.2.4", "buffer-crc32": "^0.2.1", "readable-stream": "^3.6.0", "readdir-glob": "^1.1.2", "tar-stream": "^2.2.0", "zip-stream": "^4.1.0" } }, "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw=="],
 
     "archiver-utils": ["archiver-utils@2.1.0", "", { "dependencies": { "glob": "^7.1.4", "graceful-fs": "^4.2.0", "lazystream": "^1.0.0", "lodash.defaults": "^4.2.0", "lodash.difference": "^4.5.0", "lodash.flatten": "^4.4.0", "lodash.isplainobject": "^4.0.6", "lodash.union": "^4.6.0", "normalize-path": "^3.0.0", "readable-stream": "^2.0.0" } }, "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw=="],
@@ -363,8 +360,6 @@
     "big-integer": ["big-integer@1.6.52", "", {}, "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg=="],
 
     "binary": ["binary@0.3.0", "", { "dependencies": { "buffers": "~0.1.1", "chainsaw": "~0.1.0" } }, "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg=="],
-
-    "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
 
     "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
 
@@ -406,8 +401,6 @@
 
     "cheerio-select": ["cheerio-select@2.1.0", "", { "dependencies": { "boolbase": "^1.0.0", "css-select": "^5.1.0", "css-what": "^6.1.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1" } }, "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g=="],
 
-    "chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
-
     "ci-info": ["ci-info@4.3.0", "", {}, "sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
@@ -415,8 +408,6 @@
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
-
-    "commander": ["commander@9.5.0", "", {}, "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="],
 
     "compress-commons": ["compress-commons@4.1.2", "", { "dependencies": { "buffer-crc32": "^0.2.13", "crc32-stream": "^4.0.2", "normalize-path": "^3.0.0", "readable-stream": "^3.6.0" } }, "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg=="],
 
@@ -566,8 +557,6 @@
 
     "get-stdin": ["get-stdin@5.0.1", "", {}, "sha512-jZV7n6jGE3Gt7fgSTJoz91Ak5MuTLwMwkoYdjxuJ/AmjIsE1UC03y/IWkZCQGEvVNS9qoRNwy5BCqxImv0FVeA=="],
 
-    "get-tsconfig": ["get-tsconfig@4.10.1", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ=="],
-
     "glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
@@ -611,8 +600,6 @@
     "inflight": ["inflight@1.0.6", "", { "dependencies": { "once": "^1.3.0", "wrappy": "1" } }, "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
-
-    "is-binary-path": ["is-binary-path@2.1.0", "", { "dependencies": { "binary-extensions": "^2.0.0" } }, "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw=="],
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
@@ -728,8 +715,6 @@
 
     "mustache": ["mustache@4.2.0", "", { "bin": { "mustache": "bin/mustache" } }, "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ=="],
 
-    "mylas": ["mylas@2.1.13", "", {}, "sha512-+MrqnJRtxdF+xngFfUUkIMQrUUL0KsxbADUkn23Z/4ibGg192Q+z+CQyiYwvWTsYjJygmMR8+w3ZDa98Zh6ESg=="],
-
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
@@ -790,8 +775,6 @@
 
     "pixelmatch": ["pixelmatch@5.3.0", "", { "dependencies": { "pngjs": "^6.0.0" }, "bin": { "pixelmatch": "bin/pixelmatch" } }, "sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q=="],
 
-    "plimit-lit": ["plimit-lit@1.6.1", "", { "dependencies": { "queue-lit": "^1.5.1" } }, "sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA=="],
-
     "pngjs": ["pngjs@3.4.0", "", {}, "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="],
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
@@ -812,8 +795,6 @@
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
-    "queue-lit": ["queue-lit@1.5.2", "", {}, "sha512-tLc36IOPeMAubu8BkW8YDBV+WyIgKlYU7zUNs0J5Vk9skSZ4JfGlPOqplP0aHdfv7HL0B2Pg6nwiq60Qc6M2Hw=="],
-
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
     "react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
@@ -822,11 +803,7 @@
 
     "readdir-glob": ["readdir-glob@1.1.3", "", { "dependencies": { "minimatch": "^5.1.0" } }, "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA=="],
 
-    "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
-
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
-
-    "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
     "retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
 
@@ -908,8 +885,6 @@
 
     "ts-api-utils": ["ts-api-utils@1.4.3", "", { "peerDependencies": { "typescript": ">=4.2.0" } }, "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw=="],
 
-    "tsc-alias": ["tsc-alias@1.8.16", "", { "dependencies": { "chokidar": "^3.5.3", "commander": "^9.0.0", "get-tsconfig": "^4.10.0", "globby": "^11.0.4", "mylas": "^2.1.9", "normalize-path": "^3.0.0", "plimit-lit": "^1.2.6" }, "bin": { "tsc-alias": "dist/bin/index.js" } }, "sha512-QjCyu55NFyRSBAl6+MTFwplpFcnm2Pq01rR/uxfqJoLMm6X3O14KEGtaSDZpJYaE1bJBGDjD0eSuiIWPe2T58g=="],
-
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
@@ -970,13 +945,9 @@
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
-    "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
-
     "archiver-utils/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
     "chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
-    "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "duplexer2/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
@@ -1001,8 +972,6 @@
     "pixelmatch/pngjs": ["pngjs@6.0.0", "", {}, "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg=="],
 
     "readdir-glob/minimatch": ["minimatch@5.1.6", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g=="],
-
-    "readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "stack-utils/escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "bun run --hot src/index.ts",
     "start": "node dist/index.js",
     "test": "vitest",
-    "build": "tsc && tsc-alias",
+    "build": "tsc",
     "lint": "eslint src/**/*.ts",
     "lint:fix": "eslint src/**/*.ts --fix",
     "format": "prettier --write src/**/*.ts",
@@ -47,7 +47,6 @@
     "jest-image-snapshot": "^6.5.1",
     "prettier": "^3.2.5",
     "sharp": "^0.34.4",
-    "tsc-alias": "^1.8.16",
     "typescript": "^5.3.3",
     "vitest": "^3.2.4"
   }

--- a/src/agents/core-agent/coreAgent.ts
+++ b/src/agents/core-agent/coreAgent.ts
@@ -5,16 +5,16 @@ import {
   START,
   StateGraph,
 } from '@langchain/langgraph';
-import { QueryAgentSummarySchema } from '@lib/annotation';
-import { openai } from '@llms';
+import { QueryAgentSummarySchema } from '../../lib/annotation.ts';
+import { openai } from '../../llms/index.ts';
 import { z } from 'zod';
-import { queryAgent, searchAgent } from '..';
-import { getPackage } from '@lib/data-gov';
+import { queryAgent, searchAgent } from '../index.ts';
+import { getPackage } from '../../lib/data-gov.ts';
 import {
   DATA_GOV_FINAL_EVALUATION_PROMPT,
   DATA_GOV_USER_QUERY_FORMATTING_PROMPT,
-} from './prompts';
-import { DatasetWithEvaluation } from '@agents/search-agent/searchAgent';
+} from './prompts.ts';
+import { DatasetWithEvaluation } from '../search-agent/searchAgent.ts';
 
 /*
 // TODO: Follow up on this comment - do I still need it?

--- a/src/agents/eval-agent/evalAgent.ts
+++ b/src/agents/eval-agent/evalAgent.ts
@@ -1,11 +1,11 @@
 import { Annotation, END, Send, START, StateGraph } from '@langchain/langgraph';
-import { openai } from '@llms';
+import { openai } from '../../llms/index.ts';
 import { PendingResource, DatasetSummary, SummarySchema } from './annotations';
-import { PackageShowResponse } from '@lib/data-gov.schemas';
+import { PackageShowResponse } from '../../lib/data-gov.schemas.ts';
 import { DATA_GOV_SHALLOW_EVAL_SUMMATIVE_PROMPT } from './prompts';
-import { VALID_DATASET_FORMATS } from '@tools/datasetDownload';
+import { VALID_DATASET_FORMATS } from '../../tools/datasetDownload.ts';
 import { ResourceEvaluationAnnotation } from '../resource-eval-agent/resourceEvalAgent';
-import { resourceEvalAgent } from '..';
+import { resourceEvalAgent } from '../index.ts';
 import { ResourceEvaluation } from '../resource-eval-agent/annotations';
 
 /**

--- a/src/agents/query-agent/queryAgent.ts
+++ b/src/agents/query-agent/queryAgent.ts
@@ -12,19 +12,19 @@ import {
   QUERY_AGENT_SQL_REMINDER_PROMPT,
   QUERY_AGENT_TABLE_NAME_PROMPT,
 } from './prompts';
-import { QueryAgentSummarySchema } from '@lib/annotation';
-import { openai } from '@llms';
+import { QueryAgentSummarySchema } from '../../lib/annotation.ts';
+import { openai } from '../../llms/index.ts';
 import { ToolNode } from '@langchain/langgraph/prebuilt';
 import { AIMessage } from '@langchain/core/messages';
 import { z } from 'zod';
-import { datasetDownload } from '@tools/datasetDownload';
+import { datasetDownload } from '../../tools/datasetDownload.ts';
 import path from 'path';
 import fs from 'fs';
 import os from 'os';
-import { getLastAiMessageIndex, getToolMessages } from '@lib/utils';
-import { conn, workingDatasetMemory } from '@lib/database';
-import { sqlQueryTool } from '@tools';
-import { DatasetWithEvaluation } from '@agents/search-agent/searchAgent';
+import { getLastAiMessageIndex, getToolMessages } from '../../lib/utils.ts';
+import { conn, workingDatasetMemory } from '../../lib/database.ts';
+import { sqlQueryTool } from '../../tools/index.ts';
+import { DatasetWithEvaluation } from '../search-agent/searchAgent.ts';
 
 const MAX_QUERY_COUNT = 5;
 

--- a/src/agents/resource-eval-agent/resourceEvalAgent.ts
+++ b/src/agents/resource-eval-agent/resourceEvalAgent.ts
@@ -1,12 +1,12 @@
 import { Annotation, END, START, StateGraph } from '@langchain/langgraph';
-import { PendingResource } from '@agents/eval-agent/annotations';
-import { openai } from '@llms';
+import { PendingResource } from '../eval-agent/annotations';
+import { openai } from '../../llms/index.ts';
 import { z } from 'zod';
 import {
   DATA_GOV_DEEP_EVAL_SINGLE_RESOURCE_PROMPT,
   DATA_GOV_SHALLOW_EVAL_SINGLE_RESOURCE_PROMPT,
 } from './prompts';
-import { datasetDownload, doiView } from '@tools';
+import { datasetDownload, doiView } from '../../tools/index.ts';
 import { ResourceEvaluationSchema, ResourceEvaluation } from './annotations';
 
 /* ANNOTATIONS */

--- a/src/agents/search-agent/searchAgent.ts
+++ b/src/agents/search-agent/searchAgent.ts
@@ -7,15 +7,15 @@ import {
   StateGraph,
 } from '@langchain/langgraph';
 import { ToolNode } from '@langchain/langgraph/prebuilt';
-import { packageSearch, packageNameSearch, packageShow } from '@tools';
-import { openai } from '@llms';
+import { packageSearch, packageNameSearch, packageShow } from '../../tools/index.ts';
+import { openai } from '../../llms/index.ts';
 import {
   DATA_GOV_SEARCH_PROMPT,
   DATA_GOV_SEARCH_REMINDER_PROMPT as DATA_GOV_SEARCH_SELECTION_PROMPT,
 } from './prompts';
-import { getLastAiMessageIndex, getToolMessages } from '@lib/utils';
+import { getLastAiMessageIndex, getToolMessages } from '../../lib/utils.ts';
 import { z } from 'zod';
-import shallowEvalAgent from '@agents/eval-agent/evalAgent';
+import shallowEvalAgent from '../eval-agent/evalAgent.ts';
 import { DatasetSummary } from '../eval-agent/annotations';
 import { ResourceEvaluation } from '../resource-eval-agent/annotations';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { coreAgent } from '@agents';
+import { coreAgent } from './agents/index.ts';
 import testing from './routes/testing';
 import agents from './routes/agents';
 

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -1,4 +1,4 @@
-import { DatasetWithEvaluation } from '@agents/search-agent/searchAgent';
+import { DatasetWithEvaluation } from '../agents/search-agent/searchAgent.ts';
 
 export const MOCK_USER_QUERY = {
   query:

--- a/src/routes/agents.ts
+++ b/src/routes/agents.ts
@@ -1,8 +1,8 @@
 import { Hono } from 'hono';
-import { searchAgent, evalAgent, queryAgent } from '@agents';
-import { datasetDownload } from '@tools';
-import { DATA_GOV_USER_QUERY_FORMATTING_PROMPT } from '@agents/core-agent/prompts';
-import { openai } from '@llms';
+import { searchAgent, evalAgent, queryAgent } from '../agents/index.ts';
+import { datasetDownload } from '../tools/index.ts';
+import { DATA_GOV_USER_QUERY_FORMATTING_PROMPT } from '../agents/core-agent/prompts.ts';
+import { openai } from '../llms/index.ts';
 import { z } from 'zod';
 
 /**

--- a/src/routes/testing.ts
+++ b/src/routes/testing.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
-import { searchAgent, evalAgent, queryAgent, resourceEvalAgent } from '@agents';
-import { packageShow, datasetDownload } from '@tools';
+import { searchAgent, evalAgent, queryAgent, resourceEvalAgent } from '../agents/index.ts';
+import { packageShow, datasetDownload } from '../tools/index.ts';
 import { ResourceEvaluation } from '../agents/resource-eval-agent/annotations';
 
 /**

--- a/src/tools/datasetDownload.ts
+++ b/src/tools/datasetDownload.ts
@@ -1,7 +1,7 @@
 import { tool } from '@langchain/core/tools';
 import { z } from 'zod';
-import { ONE_SECOND } from '@lib/utils';
-import { workingDatasetMemory } from '@lib/database';
+import { ONE_SECOND } from '../lib/utils.ts';
+import { workingDatasetMemory } from '../lib/database.ts';
 
 export const VALID_DATASET_FORMATS = ['CSV'] as const;
 

--- a/src/tools/doiView.ts
+++ b/src/tools/doiView.ts
@@ -1,7 +1,7 @@
 import { tool } from '@langchain/core/tools';
 import { z } from 'zod';
 import * as cheerio from 'cheerio';
-import { ONE_SECOND } from '@lib/utils';
+import { ONE_SECOND } from '../lib/utils.ts';
 import * as ExcelJS from 'exceljs';
 
 /**

--- a/src/tools/packageNameSearch.ts
+++ b/src/tools/packageNameSearch.ts
@@ -1,6 +1,6 @@
 import { tool } from '@langchain/core/tools';
 import { z } from 'zod';
-import { packageAutocomplete } from '@lib/data-gov';
+import { packageAutocomplete } from '../lib/data-gov.ts';
 
 /**
  * Get a list of related package names to a query from data.gov

--- a/src/tools/packageSearch.ts
+++ b/src/tools/packageSearch.ts
@@ -1,7 +1,7 @@
 import { tool } from '@langchain/core/tools';
 import { z } from 'zod';
-import { searchPackages } from '@lib/data-gov';
-import { PackageShowSchema } from '@lib/data-gov.schemas';
+import { searchPackages } from '../lib/data-gov.ts';
+import { PackageShowSchema } from '../lib/data-gov.schemas.ts';
 
 /**
  * Search for packages (datasets) on data.gov using the CKAN API

--- a/src/tools/packageShow.ts
+++ b/src/tools/packageShow.ts
@@ -1,7 +1,7 @@
 import { tool } from '@langchain/core/tools';
 import { z } from 'zod';
-import { getPackage } from '@lib/data-gov';
-import { PackageShowSchema } from '@lib/data-gov.schemas';
+import { getPackage } from '../lib/data-gov.ts';
+import { PackageShowSchema } from '../lib/data-gov.schemas.ts';
 
 /**
  * Get detailed metadata for a specific package (dataset) from data.gov

--- a/src/tools/sqlQuery.ts
+++ b/src/tools/sqlQuery.ts
@@ -1,5 +1,5 @@
 import { tool } from 'langchain';
-import { conn } from '@lib/database';
+import { conn } from '../lib/database.ts';
 import { z } from 'zod';
 
 export const sqlQueryTool = tool(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
+    "outDir": "dist",
     "moduleDetection": "force",
     "noEmit": true,
     "composite": false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
-    "outDir": "dist",
     "moduleDetection": "force",
     "noEmit": true,
     "composite": false,
@@ -16,17 +15,7 @@
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
     "allowJs": true,
-    "types": ["bun-types"],
-    "baseUrl": "src",
-    "paths": {
-      "@lib/*": ["./src/lib/*"],
-      "@agents/*": ["./src/agents/*"],
-      "@tools/*": ["./src/tools/*"],
-      "@llms/*": ["./src/llms/*"],
-      "@llms": ["./src/llms/index.ts"],
-      "@tools": ["./src/tools/index.ts"],
-      "@agents": ["./src/agents/index.ts"]
-    }
+    "types": ["bun-types"]
   },
   "include": ["src/**/*", "test/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "forceConsistentCasingInFileNames": true,
     "allowJs": true,
     "types": ["bun-types"],
+    "baseUrl": "src",
     "paths": {
       "@lib/*": ["./src/lib/*"],
       "@agents/*": ["./src/agents/*"],


### PR DESCRIPTION
Bun + DuckDB/node-api causes issues with Vercel, so a small adjustment needs to be made for how the production build gets built + run. This is done with minimal invasiveness as follows:

1. Add `tsc` and `tsc-alias` (done in direct commit already)